### PR TITLE
Add Skeleton placeholders when loading data

### DIFF
--- a/src/components/children/children-manager.tsx
+++ b/src/components/children/children-manager.tsx
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { Skeleton } from '@/components/ui/skeleton';
 import { toast } from '@/hooks/use-toast';
 import { PlusCircleIcon, PencilIcon, TrashIcon, UserIcon, EyeIcon } from 'lucide-react';
 import { useAuth } from '@/context/auth-context';
@@ -204,7 +205,13 @@ export function ChildrenManager() {
   };
 
   if (loading) {
-    return <div>Chargement...</div>;
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <Skeleton key={idx} className="h-40 w-full rounded-xl" />
+        ))}
+      </div>
+    );
   }
 
   return (

--- a/src/components/rewards/rewards-manager.tsx
+++ b/src/components/rewards/rewards-manager.tsx
@@ -8,6 +8,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { toast } from '@/hooks/use-toast';
 import { PlusCircleIcon, PencilIcon, TrashIcon } from 'lucide-react';
 import { useAuth } from '@/context/auth-context';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface Reward {
   id: string;
@@ -152,7 +153,13 @@ export function RewardsManager() {
   };
 
   if (loading) {
-    return <div>Chargement...</div>;
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <Skeleton key={idx} className="h-40 w-full rounded-xl" />
+        ))}
+      </div>
+    );
   }
 
   return (

--- a/src/components/riddles/riddles-manager.tsx
+++ b/src/components/riddles/riddles-manager.tsx
@@ -9,6 +9,7 @@ import { BrainIcon, PlusIcon, TrashIcon, EditIcon } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { toast } from '@/hooks/use-toast';
 import { useAuth } from '@/context/auth-context';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface Riddle {
   id: string;
@@ -150,8 +151,13 @@ export function RiddlesManager() {
 
   if (isLoading) {
     return (
-      <div className="flex items-center justify-center p-8">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-600"></div>
+      <div className="space-y-4">
+        <Skeleton className="h-24 w-full rounded-xl" />
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          {Array.from({ length: 2 }).map((_, idx) => (
+            <Skeleton key={idx} className="h-32 w-full rounded-xl" />
+          ))}
+        </div>
       </div>
     );
   }

--- a/src/components/rules/rules-manager.tsx
+++ b/src/components/rules/rules-manager.tsx
@@ -8,6 +8,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from 
 import { toast } from '@/hooks/use-toast';
 import { PlusCircleIcon, PencilIcon, TrashIcon } from 'lucide-react';
 import { useAuth } from '@/context/auth-context';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface Rule {
   id: string;
@@ -152,7 +153,13 @@ export function RulesManager() {
   };
 
   if (loading) {
-    return <div>Chargement...</div>;
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <Skeleton key={idx} className="h-40 w-full rounded-xl" />
+        ))}
+      </div>
+    );
   }
 
   return (

--- a/src/components/tasks/tasks-manager.tsx
+++ b/src/components/tasks/tasks-manager.tsx
@@ -9,6 +9,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { toast } from '@/hooks/use-toast';
 import { PlusCircleIcon, PencilIcon, TrashIcon } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useAuth } from '@/context/auth-context';
 
 interface Task {
@@ -230,7 +231,13 @@ export function TasksManager() {
   };
 
   if (loading) {
-    return <div>Chargement...</div>;
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <Skeleton key={idx} className="h-40 w-full rounded-xl" />
+        ))}
+      </div>
+    );
   }
 
   return (

--- a/src/pages/dashboard-child.tsx
+++ b/src/pages/dashboard-child.tsx
@@ -6,7 +6,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Progress } from '@/components/ui/progress';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
-import { GiftIcon, TrophyIcon, ListChecksIcon, StarIcon, SparklesIcon, CheckCircleIcon, PartyPopperIcon, BrainIcon, CalendarIcon, FlameIcon } from 'lucide-react';
+import { GiftIcon, TrophyIcon, ListChecksIcon, StarIcon, CheckCircleIcon, PartyPopperIcon, BrainIcon, CalendarIcon, FlameIcon } from 'lucide-react';
 import { supabase } from '@/lib/supabase';
 import { toast } from '@/hooks/use-toast';
 import { Label } from '@/components/ui/label';
@@ -15,6 +15,7 @@ import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface Child {
   id: string;
@@ -545,41 +546,14 @@ export default function DashboardChild() {
 
   if (loading || isLoading) {
     return (
-      <motion.div 
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        className="flex items-center justify-center min-h-screen bg-gradient-to-br from-indigo-100 via-purple-50 to-pink-100"
-      >
-        <div className="text-center relative">
-          <motion.div 
-            animate={{ 
-              rotate: 360,
-              scale: [1, 1.2, 1],
-            }}
-            transition={{ 
-              rotate: { duration: 2, repeat: Infinity, ease: "linear" },
-              scale: { duration: 1.5, repeat: Infinity }
-            }}
-            className="rounded-full h-20 w-20 bg-gradient-to-br from-purple-500 to-pink-500 mx-auto mb-6 flex items-center justify-center shadow-2xl"
-          >
-            <SparklesIcon className="h-10 w-10 text-white" />
-          </motion.div>
-          <motion.p 
-            animate={{ opacity: [0.5, 1, 0.5] }}
-            transition={{ duration: 2, repeat: Infinity }}
-            className="text-2xl font-bold bg-gradient-to-r from-purple-600 to-pink-600 bg-clip-text text-transparent"
-          >
-            Chargement de ton monde magique...
-          </motion.p>
-          <motion.div
-            animate={{ y: [-5, 5, -5] }}
-            transition={{ duration: 1, repeat: Infinity }}
-            className="text-4xl mt-4"
-          >
-            ✨
-          </motion.div>
+      <div className="p-6 space-y-6">
+        <Skeleton className="h-10 w-40" />
+        <div className="grid grid-cols-1 lg:grid-cols-12 gap-8">
+          <Skeleton className="h-64 lg:col-span-3 rounded-xl" />
+          <Skeleton className="h-64 lg:col-span-6 rounded-xl" />
+          <Skeleton className="h-64 lg:col-span-3 rounded-xl" />
         </div>
-      </motion.div>
+      </div>
     );
   }
 

--- a/src/pages/dashboard-parent.tsx
+++ b/src/pages/dashboard-parent.tsx
@@ -12,7 +12,6 @@ import {
   ArrowLeft,
   Sparkles,
   Info,
-  Loader2,
   RefreshCw,
   Calendar,
   ChevronDown,
@@ -55,6 +54,7 @@ import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip as RechartsToolti
 import { format, subDays, subWeeks, subMonths, startOfDay, endOfDay, addDays } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { Skeleton } from '@/components/ui/skeleton';
 
 type View = 'children' | 'tasks' | 'rules' | 'rewards' | 'riddles' | null;
 type Period = 'day' | 'week' | 'month';
@@ -137,15 +137,7 @@ const StatCard = ({ title, value, icon, color, isLoading, details, trend, subtit
             </div>
             
             {isLoading ? (
-              <div className="flex items-center gap-3 mt-2">
-                <motion.div
-                  animate={{ rotate: 360 }}
-                  transition={{ duration: 1, repeat: Infinity, ease: "linear" }}
-                >
-                  <Loader2 className="h-5 w-5 text-gray-400" />
-                </motion.div>
-                <span className="text-sm text-gray-500">Chargement...</span>
-              </div>
+              <Skeleton className="h-8 w-24 mt-2" />
             ) : (
               <div>
                 <motion.h3 
@@ -451,46 +443,15 @@ export default function DashboardParent() {
     fetchStats();
   }, [user, period]);
 
-  if (loading) {
+  if (loading || stats.isLoading) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-indigo-900 via-purple-900 to-pink-900">
-        <motion.div 
-          className="text-center"
-          initial={{ opacity: 0, scale: 0.9 }}
-          animate={{ opacity: 1, scale: 1 }}
-          transition={{ duration: 0.5 }}
-        >
-          <motion.div
-            animate={{ 
-              rotate: 360,
-              scale: [1, 1.2, 1]
-            }}
-            transition={{ 
-              rotate: { duration: 2, repeat: Infinity, ease: "linear" },
-              scale: { duration: 1, repeat: Infinity }
-            }}
-            className="relative mx-auto mb-8"
-          >
-            <div className="w-16 h-16 rounded-full border-4 border-white/20" />
-            <div className="absolute top-0 left-0 w-16 h-16 rounded-full border-4 border-white border-t-transparent animate-spin" />
-          </motion.div>
-          <motion.h2 
-            className="text-2xl font-bold text-white mb-2"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.2 }}
-          >
-            Chargement de votre espace
-          </motion.h2>
-          <motion.p 
-            className="text-white/80"
-            initial={{ opacity: 0, y: 20 }}
-            animate={{ opacity: 1, y: 0 }}
-            transition={{ delay: 0.4 }}
-          >
-            Préparation du tableau de bord parent...
-          </motion.p>
-        </motion.div>
+      <div className="p-6 space-y-6">
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+          {Array.from({ length: 4 }).map((_, idx) => (
+            <Skeleton key={idx} className="h-32 w-full rounded-xl" />
+          ))}
+        </div>
+        <Skeleton className="h-80 w-full rounded-xl" />
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- use `<Skeleton>` for placeholder loading states across manager components
- display skeletons instead of animated loaders in dashboard pages

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: missing dependencies for build)*

------
https://chatgpt.com/codex/tasks/task_e_684c0de3704483269d5f149f39a57b9a