### PR TITLE
Add moods tracking feature

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import AuthPage from '@/pages/auth';
 import DashboardParent from '@/pages/dashboard-parent';
 import DashboardChild from '@/pages/dashboard-child';
 import ChildHome from '@/pages/home';
+import MoodDashboard from '@/pages/mood-dashboard';
 
 // Composant de protection des routes
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
@@ -53,16 +54,24 @@ function App() {
                   </ProtectedRoute>
                 } 
               />
-              <Route 
-                path="/dashboard/child/:childName" 
+              <Route
+                path="/dashboard/child/:childName"
                 element={
                   <ProtectedRoute>
                     <DashboardChild />
                   </ProtectedRoute>
-                } 
+                }
               />
-              <Route 
-                path="/child/:childName" 
+              <Route
+                path="/dashboard/moods"
+                element={
+                  <ProtectedRoute>
+                    <MoodDashboard />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/child/:childName"
                 element={
                   <ProtectedRoute>
                     <ChildHome />

--- a/src/components/layout/main-nav.tsx
+++ b/src/components/layout/main-nav.tsx
@@ -106,6 +106,15 @@ export function MainNav() {
                             Parent Dashboard
                           </Button>
                         </Link>
+                        <Link to="/dashboard/moods" onClick={() => {}}>
+                          <Button
+                            variant={isActive('/dashboard/moods') ? 'default' : 'ghost'}
+                            className="w-full justify-start"
+                          >
+                            <SparklesIcon className="h-5 w-5 mr-2" />
+                            Tableau de Bord des Humeurs
+                          </Button>
+                        </Link>
                         {children.length > 0 && (
                           <>
                             {children.map((child) => (
@@ -143,6 +152,21 @@ export function MainNav() {
                     >
                       <UserIcon className="h-5 w-5 mr-2" /> 
                       Parent Dashboard
+                    </Button>
+                  </motion.div>
+                </Link>
+                <Link to="/dashboard/moods">
+                  <motion.div whileHover={{ scale: 1.05 }}>
+                    <Button
+                      variant={isActive('/dashboard/moods') ? 'default' : 'ghost'}
+                      className={`${
+                        isActive('/dashboard/moods')
+                          ? 'bg-gradient-to-r from-purple-600 to-pink-600 text-white shadow-lg'
+                          : 'hover:bg-purple-50'
+                      } transition-all duration-300`}
+                    >
+                      <SparklesIcon className="h-5 w-5 mr-2" />
+                      Tableau de Bord des Humeurs
                     </Button>
                   </motion.div>
                 </Link>

--- a/src/components/mood/mood-tracker.tsx
+++ b/src/components/mood/mood-tracker.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from '@/hooks/use-toast';
+
+interface MoodTrackerProps {
+  childId: string;
+}
+
+const MOODS = ['heureux', 'triste', 'en colère', 'fatigué', 'excité'];
+
+export function MoodTracker({ childId }: MoodTrackerProps) {
+  const [selected, setSelected] = useState<string>('');
+  const [loading, setLoading] = useState(false);
+
+  const logMood = async () => {
+    if (!selected) return;
+    setLoading(true);
+    try {
+      const today = new Date().toISOString().split('T')[0];
+      const { error } = await supabase.from('moods').insert({
+        child_id: childId,
+        mood: selected,
+        date: today,
+      });
+      if (error) throw error;
+      toast({ title: 'Humeur enregistrée' });
+      setSelected('');
+    } catch (error) {
+      toast({
+        title: 'Erreur',
+        description: "Impossible d'enregistrer l'humeur",
+        variant: 'destructive',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Card className="max-w-md mx-auto">
+      <CardHeader>
+        <CardTitle>Humeur du jour</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <div className="flex flex-wrap gap-2">
+          {MOODS.map((m) => (
+            <Button
+              key={m}
+              variant={selected === m ? 'default' : 'outline'}
+              onClick={() => setSelected(m)}
+            >
+              {m}
+            </Button>
+          ))}
+        </div>
+        <Button onClick={logMood} disabled={loading || !selected}>
+          Enregistrer
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/dashboard-child.tsx
+++ b/src/pages/dashboard-child.tsx
@@ -16,6 +16,7 @@ import { fr } from 'date-fns/locale';
 import { Input } from '@/components/ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
 import { Skeleton } from '@/components/ui/skeleton';
+import { MoodTracker } from '@/components/mood/mood-tracker';
 
 interface Child {
   id: string;
@@ -874,14 +875,28 @@ export default function DashboardChild() {
             </Card>
           </motion.div>
 
+          {/* Section de l'humeur du jour */}
+          <motion.div
+            initial={{ x: 100, opacity: 0, rotateY: 30 }}
+            animate={{ x: 0, opacity: 1, rotateY: 0 }}
+            transition={{
+              type: "spring",
+              stiffness: 100,
+              delay: 0.3
+            }}
+            className="lg:col-span-4"
+          >
+            <MoodTracker childId={child.id} />
+          </motion.div>
+
           {/* Section des tâches améliorée */}
           <motion.div
             initial={{ y: 100, opacity: 0, scale: 0.9 }}
             animate={{ y: 0, opacity: 1, scale: 1 }}
-            transition={{ 
-              type: "spring", 
+            transition={{
+              type: "spring",
               stiffness: 100,
-              delay: 0.4 
+              delay: 0.4
             }}
             className="lg:col-span-6"
           >

--- a/src/pages/mood-dashboard.tsx
+++ b/src/pages/mood-dashboard.tsx
@@ -1,0 +1,81 @@
+import { useAuth } from '@/context/auth-context';
+import { useEffect, useMemo, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { Skeleton } from '@/components/ui/skeleton';
+
+interface MoodEntry {
+  id: string;
+  child_id: string;
+  mood: string;
+  date: string;
+  child: {
+    name: string;
+  };
+}
+
+export default function MoodDashboard() {
+  const { user } = useAuth();
+  const [moods, setMoods] = useState<MoodEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (user) {
+      fetchMoods();
+    }
+  }, [user]);
+
+  const fetchMoods = async () => {
+    setLoading(true);
+    const { data, error } = await supabase
+      .from('moods')
+      .select('id, child_id, mood, date, children(name)')
+      .eq('children.user_id', user?.id)
+      .order('date', { ascending: true });
+    if (!error && data) {
+      setMoods(data as any);
+    }
+    setLoading(false);
+  };
+
+  const grouped = useMemo(() => {
+    const map: Record<string, { name: string; data: Record<string, number> }> = {};
+    moods.forEach((m) => {
+      const child = m.child?.name || 'Inconnu';
+      if (!map[child]) {
+        map[child] = { name: child, data: {} };
+      }
+      map[child].data[m.mood] = (map[child].data[m.mood] || 0) + 1;
+    });
+    return Object.values(map);
+  }, [moods]);
+
+  return (
+    <div className="p-4 space-y-6">
+      {grouped.map((group) => (
+        <Card key={group.name}>
+          <CardHeader>
+            <CardTitle>Humeurs de {group.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {loading ? (
+              <Skeleton className="h-40 w-full" />
+            ) : (
+              <ResponsiveContainer width="100%" height={200}>
+                <BarChart
+                  data={Object.entries(group.data).map(([mood, value]) => ({ mood, value }))}
+                >
+                  <XAxis dataKey="mood" />
+                  <YAxis allowDecimals={false} />
+                  <Tooltip />
+                  <Bar dataKey="value" fill="#8884d8" />
+                </BarChart>
+              </ResponsiveContainer>
+            )}
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/mood-dashboard.tsx
+++ b/src/pages/mood-dashboard.tsx
@@ -2,8 +2,12 @@ import { useAuth } from '@/context/auth-context';
 import { useEffect, useMemo, useState } from 'react';
 import { supabase } from '@/lib/supabase';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip } from 'recharts';
+import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip, CartesianGrid } from 'recharts';
+import { NameType, Payload, ValueType } from 'recharts/types/component/DefaultTooltipContent';
 import { Skeleton } from '@/components/ui/skeleton';
+import { RefreshCwIcon, SmileIcon, InfoIcon } from 'lucide-react';
+import { motion } from 'framer-motion';
+import { Button } from '@/components/ui/button';
 
 interface MoodEntry {
   id: string;
@@ -46,9 +50,7 @@ export default function MoodDashboard() {
   const grouped = useMemo(() => {
     const map: Record<string, { name: string; data: Record<string, number> }> = {};
     moods.forEach((m) => {
-      console.log('Traitement de l\'entrée d\'humeur:', m);
       const child = m.children?.name || 'Inconnu';
-      console.log('Nom de l\'enfant (après traitement):', child);
       if (!map[child]) {
         map[child] = { name: child, data: {} };
       }
@@ -57,38 +59,110 @@ export default function MoodDashboard() {
     return Object.values(map);
   }, [moods]);
 
+  const getMoodColor = (mood: string) => {
+    switch (mood) {
+      case 'heureux': return '#84cc16'; // vert
+      case 'triste': return '#60a5fa'; // bleu
+      case 'en colère': return '#ef4444'; // rouge
+      case 'fatigué': return '#f97316'; // orange
+      case 'excité': return '#ec4899'; // rose
+      default: return '#a3a3a3'; // gris
+    }
+  };
+
   return (
-    <div className="p-4 space-y-6">
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      className="p-6 space-y-8 bg-gradient-to-br from-purple-50 to-indigo-50 min-h-screen"
+    >
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <motion.h1
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            className="text-4xl font-bold text-gray-900 flex items-center gap-3 mb-2"
+          >
+            <SmileIcon className="h-10 w-10 text-yellow-500" />
+            Tableau de Bord des Humeurs
+          </motion.h1>
+          <motion.p
+            initial={{ opacity: 0, x: -20 }}
+            animate={{ opacity: 1, x: 0 }}
+            transition={{ delay: 0.1 }}
+            className="text-gray-600 text-lg"
+          >
+            Visualisez l'évolution des humeurs de vos enfants au fil du temps.
+          </motion.p>
+        </div>
+        <motion.div
+          whileHover={{ scale: 1.05 }}
+          whileTap={{ scale: 0.95 }}
+        >
+          <Button
+            onClick={fetchMoods}
+            disabled={loading}
+            className="bg-purple-600 hover:bg-purple-700 text-white shadow-lg"
+          >
+            <RefreshCwIcon className={`mr-2 h-5 w-5 ${loading ? 'animate-spin' : ''}`} />
+            Actualiser
+          </Button>
+        </motion.div>
+      </div>
+
       {loading ? (
-        <Skeleton className="h-40 w-full" />
+        <Skeleton className="h-64 w-full rounded-lg" />
       ) : grouped.length === 0 ? (
-        <Card className="text-center p-8">
-          <CardTitle className="mb-4">Aucune humeur enregistrée</CardTitle>
-          <CardContent>
-            <p className="text-gray-600">Commencez par enregistrer l'humeur de vos enfants sur leur tableau de bord respectif.</p>
+        <motion.div
+          initial={{ opacity: 0, scale: 0.9 }}
+          animate={{ opacity: 1, scale: 1 }}
+          className="bg-white/70 backdrop-blur-md rounded-lg p-10 text-center shadow-xl border border-gray-200"
+        >
+          <InfoIcon className="h-16 w-16 text-blue-500 mx-auto mb-6" />
+          <CardTitle className="mb-4 text-3xl font-bold text-gray-800">Aucune humeur enregistrée</CardTitle>
+          <CardContent className="p-0">
+            <p className="text-lg text-gray-600">Commencez par enregistrer l'humeur de vos enfants sur leur tableau de bord respectif pour voir les données ici.</p>
           </CardContent>
-        </Card>
+        </motion.div>
       ) : (
-        grouped.map((group) => (
-          <Card key={group.name}>
-            <CardHeader>
-              <CardTitle>Humeurs de {group.name}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <ResponsiveContainer width="100%" height={200}>
-                <BarChart
-                  data={Object.entries(group.data).map(([mood, value]) => ({ mood, value }))}
-                >
-                  <XAxis dataKey="mood" />
-                  <YAxis allowDecimals={false} />
-                  <Tooltip />
-                  <Bar dataKey="value" fill="#8884d8" />
-                </BarChart>
-              </ResponsiveContainer>
-            </CardContent>
-          </Card>
+        grouped.map((group, index) => (
+          <motion.div
+            key={group.name}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.1 }}
+          >
+            <Card className="bg-white/70 backdrop-blur-md shadow-xl border border-gray-200 rounded-lg overflow-hidden">
+              <CardHeader className="bg-gradient-to-r from-blue-500 to-purple-600 text-white p-5">
+                <CardTitle className="text-2xl font-bold">Humeurs de {group.name}</CardTitle>
+              </CardHeader>
+              <CardContent className="p-6">
+                <ResponsiveContainer width="100%" height={250}>
+                  <BarChart
+                    data={Object.entries(group.data).map(([mood, value]) => ({ mood, value }))}
+                    margin={{
+                      top: 20, right: 30, left: 20, bottom: 5,
+                    }}
+                  >
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+                    <XAxis dataKey="mood" axisLine={false} tickLine={false} padding={{ left: 20, right: 20 }} />
+                    <YAxis allowDecimals={false} stroke="#6b7280" />
+                    <Tooltip cursor={{ fill: 'transparent' }}
+                      formatter={(value: ValueType, name: NameType, props: Payload<ValueType, NameType>) => [`${value} fois`, props.payload.mood]}
+                      labelFormatter={(label: any) => `Humeur: ${label}`}
+                    />
+                    <Bar dataKey="value" fill="#8884d8">
+                      {Object.entries(group.data).map(([mood, value], idx) => (
+                        <Bar key={mood} dataKey={mood} fill={getMoodColor(mood)} />
+                      ))}
+                    </Bar>
+                  </BarChart>
+                </ResponsiveContainer>
+              </CardContent>
+            </Card>
+          </motion.div>
         ))
       )}
-    </div>
+    </motion.div>
   );
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -96,6 +96,14 @@ export interface PointsHistory {
   created_at: string;
 }
 
+export interface Mood {
+  id: string;
+  child_id: string;
+  mood: string;
+  date: string;
+  created_at: string;
+}
+
 export interface AuthContextType {
   user: User | null;
   loading: boolean;

--- a/supabase/migrations/20250613121523_add_moods_table.sql
+++ b/supabase/migrations/20250613121523_add_moods_table.sql
@@ -1,0 +1,21 @@
+/*
+  # Ajout de la table moods
+
+  Cette migration crée la table `moods` pour enregistrer l'humeur quotidienne des enfants.
+*/
+
+CREATE TABLE IF NOT EXISTS moods (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  child_id uuid REFERENCES children(id) ON DELETE CASCADE NOT NULL,
+  mood text NOT NULL,
+  date date NOT NULL,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE moods ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Parents can manage moods for their children"
+  ON moods FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM children WHERE id = child_id AND user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM children WHERE id = child_id AND user_id = auth.uid()));


### PR DESCRIPTION
## Summary
- add migration to create `moods` table in Supabase
- add `Mood` interface to TypeScript types
- build `MoodTracker` component for children to log their mood
- create `MoodDashboard` page to display mood trends
- hook new page into router

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c15e7333c832680d9d16aef173fa3