### PR TITLE
Add leaderboard view and page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import AuthPage from '@/pages/auth';
 import DashboardParent from '@/pages/dashboard-parent';
 import DashboardChild from '@/pages/dashboard-child';
 import ChildHome from '@/pages/home';
+import LeaderboardPage from '@/pages/leaderboard';
 
 // Composant de protection des routes
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
@@ -53,16 +54,24 @@ function App() {
                   </ProtectedRoute>
                 } 
               />
-              <Route 
-                path="/dashboard/child/:childName" 
+              <Route
+                path="/dashboard/child/:childName"
                 element={
                   <ProtectedRoute>
                     <DashboardChild />
                   </ProtectedRoute>
-                } 
+                }
               />
-              <Route 
-                path="/child/:childName" 
+              <Route
+                path="/leaderboard"
+                element={
+                  <ProtectedRoute>
+                    <LeaderboardPage />
+                  </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/child/:childName"
                 element={
                   <ProtectedRoute>
                     <ChildHome />

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -8,3 +8,47 @@ if (!supabaseUrl || !supabaseAnonKey) {
 }
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+
+import { startOfDay, subDays, subWeeks, subMonths } from 'date-fns';
+
+export interface LeaderboardEntry {
+  child_id: string;
+  name: string;
+  avatar_url: string | null;
+  points: number;
+}
+
+export async function fetchLeaderboard(period: 'day' | 'week' | 'month'): Promise<LeaderboardEntry[]> {
+  const endDate = new Date();
+  const startDate =
+    period === 'day'
+      ? subDays(endDate, 1)
+      : period === 'week'
+        ? subWeeks(endDate, 1)
+        : subMonths(endDate, 1);
+
+  const { data, error } = await supabase
+    .from('child_points_daily')
+    .select('child_id,name,avatar_url,points,day')
+    .gte('day', startOfDay(startDate).toISOString())
+    .lte('day', endDate.toISOString());
+
+  if (error) {
+    throw error;
+  }
+
+  const aggregated: Record<string, LeaderboardEntry> = {};
+  (data || []).forEach((row) => {
+    if (!aggregated[row.child_id]) {
+      aggregated[row.child_id] = {
+        child_id: row.child_id,
+        name: row.name,
+        avatar_url: row.avatar_url,
+        points: 0,
+      };
+    }
+    aggregated[row.child_id].points += row.points as number;
+  });
+
+  return Object.values(aggregated).sort((a, b) => b.points - a.points);
+}

--- a/src/pages/dashboard-parent.tsx
+++ b/src/pages/dashboard-parent.tsx
@@ -564,6 +564,18 @@ export default function DashboardParent() {
       accent: 'bg-cyan-500'
     },
     {
+      id: 'leaderboard',
+      title: 'Leaderboard',
+      description: 'Classement des enfants par points.',
+      icon: Trophy,
+      color: 'from-blue-500 to-indigo-500',
+      hoverColor: 'hover:from-blue-600 hover:to-indigo-600',
+      bgGradient: 'bg-gradient-to-br from-blue-50 to-indigo-100',
+      borderColor: 'border-blue-200',
+      buttonText: 'Voir le Classement',
+      accent: 'bg-blue-500'
+    },
+    {
       id: 'shop',
       title: 'Gérer la Boutique',
       description: 'Créez et gérez les articles que vos enfants peuvent acheter avec leurs points.',
@@ -1001,7 +1013,11 @@ export default function DashboardParent() {
                     <h3 className="text-xl font-bold text-gray-800 mb-2">{card.title}</h3>
                     <p className="text-sm text-gray-600 mb-4">{card.description}</p>
                     <Button
-                      onClick={() => setCurrentView(card.id as View)}
+                      onClick={() =>
+                        card.id === 'leaderboard'
+                          ? navigate('/leaderboard')
+                          : setCurrentView(card.id as View)
+                      }
                       className={`bg-gradient-to-r ${card.color} hover:from-purple-600 hover:to-indigo-700 text-white font-medium px-6 py-2 rounded-lg transition-all duration-300 transform group-hover:scale-105`}
                     >
                       {card.buttonText}

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '@/context/auth-context';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { fetchLeaderboard, LeaderboardEntry } from '@/lib/supabase';
+import { ArrowLeft, Trophy } from 'lucide-react';
+
+export default function LeaderboardPage() {
+  const { user, loading } = useAuth();
+  const navigate = useNavigate();
+  const [period, setPeriod] = useState<'day' | 'week' | 'month'>('week');
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      navigate('/auth');
+    }
+  }, [loading, user, navigate]);
+
+  useEffect(() => {
+    if (user) {
+      loadData();
+    }
+  }, [user, period]);
+
+  const loadData = async () => {
+    setIsLoading(true);
+    try {
+      const data = await fetchLeaderboard(period);
+      setEntries(data);
+    } catch (err) {
+      console.error('Erreur chargement leaderboard', err);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      <Button variant="ghost" size="icon" onClick={() => navigate('/dashboard/parent')}>
+        <ArrowLeft className="h-5 w-5" />
+      </Button>
+      <Card className="bg-white/90 backdrop-blur-xl shadow-xl border-0 rounded-2xl max-w-xl mx-auto">
+        <CardHeader className="flex items-center justify-between">
+          <div className="flex items-center gap-2">
+            <Trophy className="h-6 w-6 text-yellow-500" />
+            <CardTitle className="text-2xl font-bold">Leaderboard</CardTitle>
+          </div>
+          <Select value={period} onValueChange={value => setPeriod(value as 'day' | 'week' | 'month')}>
+            <SelectTrigger className="w-[120px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="day">Jour</SelectItem>
+              <SelectItem value="week">Semaine</SelectItem>
+              <SelectItem value="month">Mois</SelectItem>
+            </SelectContent>
+          </Select>
+        </CardHeader>
+        <CardContent>
+          {isLoading ? (
+            <p className="text-center text-sm text-gray-500">Chargement...</p>
+          ) : entries.length > 0 ? (
+            <ul className="space-y-4">
+              {entries.map((entry, idx) => (
+                <li key={entry.child_id} className="flex items-center justify-between p-3 bg-gray-50 rounded-xl">
+                  <div className="flex items-center gap-3">
+                    <Avatar className="h-10 w-10 ring-2 ring-purple-200">
+                      <AvatarImage src={entry.avatar_url || undefined} />
+                      <AvatarFallback className="bg-purple-500 text-white font-bold">
+                        {entry.name.substring(0, 2)}
+                      </AvatarFallback>
+                    </Avatar>
+                    <span className="font-medium text-gray-800">
+                      {idx + 1}. {entry.name}
+                    </span>
+                  </div>
+                  <span className="font-bold text-purple-600">{entry.points} pts</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="text-center text-gray-500">Aucun résultat</p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+

--- a/supabase/migrations/20250613114000_create_leaderboard_view.sql
+++ b/supabase/migrations/20250613114000_create_leaderboard_view.sql
@@ -1,0 +1,23 @@
+/*
+  # Vue pour le leaderboard
+
+  Cette migration crée la vue `child_points_daily` qui agrège les points gagnés
+  par chaque enfant par jour depuis la table `points_history`. La vue est créée
+  avec l'option SECURITY INVOKER afin que les politiques RLS appliquées aux
+  tables sous-jacentes garantissent qu'un parent ne peut voir que les données de
+  sa famille.
+*/
+
+create view child_points_daily
+with (security_invoker = true) as
+select
+  c.id as child_id,
+  c.user_id,
+  c.name,
+  c.avatar_url,
+  date_trunc('day', ph.created_at) as day,
+  coalesce(sum(ph.points), 0) as points
+from children c
+left join points_history ph on ph.child_id = c.id
+group by c.id, c.user_id, c.name, c.avatar_url, day;
+


### PR DESCRIPTION
## Summary
- create `child_points_daily` view for leaderboard in migrations
- fetch leaderboard data via new helper
- build leaderboard page for parents
- add route and dashboard card link

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684c50e0689c8326af7a6e00a12ee716