### PR TITLE
Add vitest setup and basic component tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,11 @@ Une application moderne et interactive pour aider les parents à gérer les tâc
    npm run dev
    ```
 
+6. Exécuter les tests :
+   ```bash
+   npm run test
+   ```
+
 ## 📱 Utilisation
 
 ### Pour commencer

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",
@@ -78,6 +79,9 @@
     "tailwindcss": "^3.4.13",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.7.0",
-    "vite": "^5.4.8"
+    "vite": "^5.4.8",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.1.3",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/__tests__/dashboard-components.test.tsx
+++ b/src/__tests__/dashboard-components.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import DashboardSection from '@/components/dashboard-section';
+import { StatCard } from '@/pages/dashboard-parent';
+
+import { Users } from 'lucide-react';
+
+describe('DashboardSection', () => {
+  it('renders its title', () => {
+    render(
+      <DashboardSection title="Test Section">
+        <p>Content</p>
+      </DashboardSection>
+    );
+    expect(screen.getByText('Test Section')).toBeInTheDocument();
+  });
+});
+
+describe('StatCard', () => {
+  it('renders value and title', () => {
+    render(
+      <StatCard
+        title="Points"
+        value={42}
+        icon={<Users data-testid="icon" />}
+        color="from-red-500 to-pink-500"
+        isLoading={false}
+      />
+    );
+    expect(screen.getByText('Points')).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+});

--- a/src/components/dashboard-section.tsx
+++ b/src/components/dashboard-section.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+
+interface DashboardSectionProps {
+  title: string;
+  children?: React.ReactNode;
+}
+
+const DashboardSection: React.FC<DashboardSectionProps> = ({ title, children }) => (
+  <section>
+    <h2>{title}</h2>
+    {children}
+  </section>
+);
+
+export default DashboardSection;

--- a/src/pages/dashboard-parent.tsx
+++ b/src/pages/dashboard-parent.tsx
@@ -115,7 +115,7 @@ interface StatCardProps {
   subtitle?: string;
 }
 
-const StatCard = ({ title, value, icon, color, isLoading, details, trend, subtitle }: StatCardProps) => (
+export const StatCard = ({ title, value, icon, color, isLoading, details, trend, subtitle }: StatCardProps) => (
   <motion.div
     whileHover={{ y: -4, scale: 1.02 }}
     transition={{ type: "spring", stiffness: 300, damping: 25 }}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import react from '@vitejs/plugin-react';
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],
@@ -11,6 +11,11 @@ export default defineConfig({
   },
   optimizeDeps: {
     exclude: ['lucide-react'],
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/setupTests.ts',
   },
   publicDir: 'public',
   build: {


### PR DESCRIPTION
## Summary
- install vitest and testing-library packages
- configure vitest in vite config and expose a `test` script
- add simple `DashboardSection` component
- export `StatCard` and add tests for both components
- document how to run the tests

## Testing
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c625017c883269e55dfe4a86735f3