### PR TITLE
Add Jest setup and component tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,13 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  setupFilesAfterEnv: ['<rootDir>/setupTests.ts'],
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+};
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "@google/generative-ai": "^0.24.1",
@@ -77,6 +78,12 @@
     "globals": "^15.9.0",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.13",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/user-event": "^14.5.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "jest-environment-jsdom": "^29.7.0",
     "typescript": "^5.3.3",
     "typescript-eslint": "^8.7.0",
     "vite": "^5.4.8"

--- a/setupTests.ts
+++ b/setupTests.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/src/components/auth/__tests__/auth-form.test.tsx
+++ b/src/components/auth/__tests__/auth-form.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthForm } from '../auth-form';
+
+const signInMock = jest.fn();
+const signUpMock = jest.fn();
+
+jest.mock('@/context/auth-context', () => ({
+  useAuth: () => ({
+    user: null,
+    loading: false,
+    signIn: signInMock,
+    signUp: signUpMock,
+    signOut: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  toast: jest.fn(),
+}));
+
+describe('AuthForm', () => {
+  it('submits login form', async () => {
+    render(<AuthForm />);
+    const email = screen.getByLabelText(/Email/i);
+    const password = screen.getByLabelText(/^Mot de passe$/i);
+    await userEvent.type(email, 'test@example.com');
+    await userEvent.type(password, 'Password1!');
+    await userEvent.click(screen.getByRole('button', { name: /Se connecter/i }));
+    expect(signInMock).toHaveBeenCalledWith('test@example.com', 'Password1!');
+  });
+
+  it('toggles to sign up and submits', async () => {
+    render(<AuthForm />);
+    await userEvent.click(screen.getByRole('button', { name: "S'inscrire" }));
+    const email = screen.getByLabelText(/Email/i);
+    const password = screen.getByLabelText(/^Mot de passe$/i);
+    const confirm = screen.getByLabelText(/Confirmer le mot de passe/i);
+    await userEvent.type(email, 'user@example.com');
+    await userEvent.type(password, 'Password1!');
+    await userEvent.type(confirm, 'Password1!');
+    await userEvent.click(screen.getByRole('button', { name: /Créer un compte/i }));
+    expect(signUpMock).toHaveBeenCalledWith('user@example.com', 'Password1!');
+  });
+});

--- a/src/components/children/__tests__/children-manager.test.tsx
+++ b/src/components/children/__tests__/children-manager.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { ChildrenManager } from '../children-manager';
+
+const fromMock = jest.fn(() => ({
+  select: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  order: jest.fn().mockResolvedValue({ data: [], error: null }),
+  insert: jest.fn(() => ({
+    select: jest.fn(() => ({
+      single: jest.fn().mockResolvedValue({ data: { id: '1', age: null }, error: null })
+    }))
+  })),
+  update: jest.fn(() => ({ eq: jest.fn().mockReturnThis() })),
+  single: jest.fn().mockResolvedValue({ data: { id: '1', age: null }, error: null }),
+  lte: jest.fn().mockReturnThis(),
+  gte: jest.fn().mockReturnThis(),
+}));
+
+jest.mock('@/lib/supabase', () => ({
+  supabase: { from: fromMock },
+}));
+
+jest.mock('@/context/auth-context', () => ({
+  useAuth: () => ({
+    user: { id: 'user1' },
+    loading: false,
+    signIn: jest.fn(),
+    signUp: jest.fn(),
+    signOut: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/use-toast', () => ({
+  toast: jest.fn(),
+}));
+
+describe('ChildrenManager', () => {
+  it('renders and submits new child', async () => {
+    render(
+      <MemoryRouter>
+        <ChildrenManager />
+      </MemoryRouter>
+    );
+
+    await waitFor(() => expect(fromMock).toHaveBeenCalledWith('children'));
+
+    await userEvent.click(screen.getByRole('button', { name: /Ajouter un enfant/i }));
+    await userEvent.type(screen.getByLabelText(/Nom/i), 'Alice');
+    await userEvent.click(screen.getByRole('button', { name: /^Ajouter$/i }));
+
+    expect(fromMock).toHaveBeenCalledWith('children');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config and setup files
- update package.json with Jest script and devDeps
- write initial tests for AuthForm and ChildrenManager

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5f4f69188326a6f4c422787523ef