### PR TITLE
Add missions and badges feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ L'application propose des idées de tâches, de règles et de récompenses grâc
 - `rules` : Règles de comportement
 - `rewards` : Catalogue de récompenses
 - `riddles` : Devinettes créées par les parents
+- `missions` : Missions éducatives à étapes
+- `badges` : Badges à collectionner
 - `shop_items` : Articles disponibles dans la boutique
 - `purchases` : Achats effectués par les enfants
 - `piggy_bank_transactions` : Mouvements de points de la tirelire
@@ -73,6 +75,9 @@ L'application propose des idées de tâches, de règles et de récompenses grâc
 - `child_tasks` : Tâches assignées aux enfants
 - `child_rules_violations` : Violations des règles
 - `child_rewards_claimed` : Récompenses réclamées
+- `mission_steps` : Étapes d'une mission
+- `child_missions` : Progression des missions par enfant
+- `child_badges` : Badges obtenus par enfant
 - `daily_riddles` : Devinettes quotidiennes par enfant
 - `points_history` : Historique des points pour analytics
 
@@ -104,8 +109,9 @@ L'application propose des idées de tâches, de règles et de récompenses grâc
    - `20250613104538_shrill_snow.sql`
    - `20250613110000_add_shop_items.sql`
    - `20250613113000_add_piggy_bank_transactions.sql`
+   - `20250615120000_add_missions_badges.sql`
    
-   Ces migrations ajoutent les contraintes d'âge, les devinettes, les articles de boutique et la table de transactions de la tirelire.
+   Ces migrations ajoutent les contraintes d'âge, les devinettes, les articles de boutique, la table de transactions de la tirelire ainsi que les missions et badges.
 
 5. Démarrer l'application :
    ```bash

--- a/src/components/badges/badge-gallery.tsx
+++ b/src/components/badges/badge-gallery.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { motion } from 'framer-motion';
+
+interface ChildBadge {
+  id: string;
+  badge: {
+    id: string;
+    title: string;
+    icon_url: string | null;
+  };
+}
+
+export function BadgeGallery({ childId }: { childId: string }) {
+  const [badges, setBadges] = useState<ChildBadge[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetchBadges();
+  }, [childId]);
+
+  const fetchBadges = async () => {
+    const { data, error } = await supabase
+      .from('child_badges')
+      .select('id, badge:badges(id,title,icon_url)')
+      .eq('child_id', childId);
+
+    if (!error) {
+      setBadges(data || []);
+    }
+    setLoading(false);
+  };
+
+  if (loading) {
+    return <Skeleton className="h-40 w-full rounded-xl" />;
+  }
+
+  return (
+    <Card className="bg-white/50 backdrop-blur-sm rounded-xl p-6 shadow-lg">
+      <CardHeader>
+        <CardTitle className="text-2xl font-bold mb-4 flex items-center gap-2">
+          Galerie de badges
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-3 gap-4">
+          {badges.map(({ id, badge }) => (
+            <motion.div key={id} whileHover={{ scale: 1.1 }} className="flex flex-col items-center">
+              {badge.icon_url && (
+                <img src={badge.icon_url} alt={badge.title} className="w-16 h-16 rounded-full" />
+              )}
+              <span className="text-sm mt-1 text-center">{badge.title}</span>
+            </motion.div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/dashboard/DashboardParent.tsx
+++ b/src/components/dashboard/DashboardParent.tsx
@@ -32,6 +32,7 @@ import { ChildrenManager } from '@/components/children/children-manager';
 import { TasksManager } from '@/components/tasks/tasks-manager';
 import { RulesManager } from '@/components/rules/rules-manager';
 import { RewardsManager } from '@/components/rewards/rewards-manager';
+import { MissionsManager } from '@/components/missions/missions-manager';
 import { RiddlesManager } from '@/components/riddles/riddles-manager';
 import {
   Select,
@@ -354,6 +355,18 @@ export const DashboardParent = () => {
       accent: 'bg-emerald-100'
     },
     {
+      id: 'missions',
+      title: 'Gérer les Missions',
+      description: 'Créez des missions ludiques avec badges à la clé.',
+      icon: Trophy,
+      color: 'text-teal-500',
+      hoverColor: 'hover:bg-teal-50',
+      bgColor: 'bg-white',
+      borderColor: 'border-gray-200',
+      buttonText: 'Gérer',
+      accent: 'bg-teal-100'
+    },
+    {
       id: 'rules',
       title: 'Gérer les Règles',
       description: 'Établissez les règles de comportement et les pénalités de points.',
@@ -616,6 +629,34 @@ export const DashboardParent = () => {
               </CardHeader>
               <CardContent className="p-6">
                 <TasksManager />
+              </CardContent>
+            </Card>
+          </motion.div>
+        )}
+
+        {currentView === 'missions' && (
+          <motion.div
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -20 }}
+            transition={{ duration: 0.2 }}
+          >
+            <Card className="bg-white/90 backdrop-blur-xl shadow-xl border-0 rounded-2xl overflow-hidden">
+              <CardHeader className="border-b border-gray-100">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-2xl font-bold text-gray-800">Gestion des Missions</CardTitle>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    onClick={() => setCurrentView(null)}
+                    className="hover:bg-gray-100"
+                  >
+                    <ArrowLeft className="h-5 w-5" />
+                  </Button>
+                </div>
+              </CardHeader>
+              <CardContent className="p-6">
+                <MissionsManager />
               </CardContent>
             </Card>
           </motion.div>

--- a/src/components/missions/missions-manager.tsx
+++ b/src/components/missions/missions-manager.tsx
@@ -1,0 +1,185 @@
+import { useState, useEffect } from 'react';
+import { supabase } from '@/lib/supabase';
+import { useAuth } from '@/context/auth-context';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from '@/components/ui/dialog';
+import { PencilIcon, TrashIcon, PlusCircleIcon } from 'lucide-react';
+import { Skeleton } from '@/components/ui/skeleton';
+import { toast } from '@/hooks/use-toast';
+
+interface Mission {
+  id: string;
+  title: string;
+  description: string | null;
+  category: string;
+  user_id: string;
+}
+
+export function MissionsManager() {
+  const { user } = useAuth();
+  const [missions, setMissions] = useState<Mission[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [editingMission, setEditingMission] = useState<Mission | null>(null);
+  const [formData, setFormData] = useState({
+    title: '',
+    description: '',
+    steps: '',
+    category: 'divers'
+  });
+
+  useEffect(() => {
+    if (user) {
+      fetchMissions();
+    }
+  }, [user]);
+
+  const fetchMissions = async () => {
+    const { data, error } = await supabase
+      .from('missions')
+      .select('*')
+      .eq('user_id', user?.id)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      toast({ title: 'Erreur', description: "Impossible de charger les missions", variant: 'destructive' });
+    } else {
+      setMissions(data || []);
+    }
+    setLoading(false);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!user) return;
+
+    const missionData = {
+      title: formData.title,
+      description: formData.description || null,
+      category: formData.category,
+      user_id: user.id
+    };
+
+    try {
+      if (editingMission) {
+        const { error } = await supabase
+          .from('missions')
+          .update(missionData)
+          .eq('id', editingMission.id)
+          .eq('user_id', user.id);
+        if (error) throw error;
+      } else {
+        const { data, error } = await supabase
+          .from('missions')
+          .insert([missionData])
+          .select()
+          .single();
+        if (error) throw error;
+        const missionId = data.id;
+        const steps = formData.steps.split('\n').filter(s => s.trim() !== '');
+        for (let i = 0; i < steps.length; i++) {
+          await supabase.from('mission_steps').insert([
+            { mission_id: missionId, label: steps[i], step_order: i + 1 }
+          ]);
+        }
+      }
+
+      toast({ title: 'Succès', description: 'Mission enregistrée' });
+      setIsDialogOpen(false);
+      setEditingMission(null);
+      setFormData({ title: '', description: '', steps: '', category: 'divers' });
+      fetchMissions();
+    } catch (err) {
+      toast({ title: 'Erreur', description: "Impossible d'enregistrer la mission", variant: 'destructive' });
+    }
+  };
+
+  const handleEdit = (mission: Mission) => {
+    setEditingMission(mission);
+    setFormData({ title: mission.title, description: mission.description || '', steps: '', category: mission.category });
+    setIsDialogOpen(true);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!user) return;
+    await supabase.from('mission_steps').delete().eq('mission_id', id);
+    await supabase.from('missions').delete().eq('id', id).eq('user_id', user.id);
+    fetchMissions();
+  };
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {Array.from({ length: 3 }).map((_, idx) => (
+          <Skeleton key={idx} className="h-40 w-full rounded-xl" />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-between items-center">
+        <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+          <DialogTrigger asChild>
+            <Button>
+              <PlusCircleIcon className="mr-2 h-4 w-4" />
+              Ajouter une mission
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="max-w-md">
+            <DialogHeader>
+              <DialogTitle>
+                {editingMission ? 'Modifier une mission' : 'Ajouter une mission'}
+              </DialogTitle>
+            </DialogHeader>
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="title">Titre</Label>
+                <Input id="title" value={formData.title} onChange={e => setFormData({ ...formData, title: e.target.value })} required />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="description">Description</Label>
+                <Textarea id="description" value={formData.description} onChange={e => setFormData({ ...formData, description: e.target.value })} />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="steps">Étapes (une par ligne)</Label>
+                <Textarea id="steps" value={formData.steps} onChange={e => setFormData({ ...formData, steps: e.target.value })} />
+              </div>
+              <Button type="submit" className="w-full">
+                {editingMission ? 'Modifier' : 'Ajouter'}
+              </Button>
+            </form>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {missions.map(mission => (
+          <Card key={mission.id}>
+            <CardHeader>
+              <CardTitle className="flex justify-between items-start">
+                <span>{mission.title}</span>
+                <div className="space-x-2">
+                  <Button variant="ghost" size="icon" onClick={() => handleEdit(mission)} aria-label="Modifier la mission">
+                    <PencilIcon className="h-4 w-4" />
+                  </Button>
+                  <Button variant="ghost" size="icon" onClick={() => handleDelete(mission.id)} aria-label="Supprimer la mission">
+                    <TrashIcon className="h-4 w-4" />
+                  </Button>
+                </div>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p>{mission.description}</p>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/pages/dashboard-child.tsx
+++ b/src/pages/dashboard-child.tsx
@@ -19,6 +19,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { ShopItemsList } from '@/components/shop/shop-items-list';
 import { PiggyBankManager } from '@/components/piggy-bank/piggy-bank-manager';
 import { ManualButton, ManualDialog } from '@/components/manual/manual-dialog';
+import { BadgeGallery } from '@/components/badges/badge-gallery';
 
 // Import des nouveaux composants
 import { AvatarDisplay } from '@/components/dashboard/AvatarDisplay';
@@ -766,11 +767,13 @@ export default function DashboardChild() {
                 <TrophyIcon className="w-6 h-6" />
                 Mes Récompenses Validées
               </h2>
-              <ValidatedRewardsList 
-                claimedRewards={claimedRewards} 
+              <ValidatedRewardsList
+                claimedRewards={claimedRewards}
                 childColor={child.custom_color}
               />
             </div>
+
+            <BadgeGallery childId={child.id} />
           </motion.div>
 
           <DailyRiddle 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -75,6 +75,48 @@ export interface PiggyBankTransaction {
   created_at: string;
 }
 
+export interface Mission {
+  id: string;
+  user_id: string;
+  title: string;
+  description?: string;
+  category: string;
+  created_at: string;
+}
+
+export interface MissionStep {
+  id: string;
+  mission_id: string;
+  label: string;
+  step_order: number;
+  created_at: string;
+}
+
+export interface ChildMission {
+  id: string;
+  child_id: string;
+  mission_id: string;
+  current_step: number;
+  is_completed: boolean;
+  validated: boolean;
+  created_at: string;
+}
+
+export interface Badge {
+  id: string;
+  title: string;
+  description?: string;
+  icon_url?: string;
+  created_at: string;
+}
+
+export interface ChildBadge {
+  id: string;
+  child_id: string;
+  badge_id: string;
+  awarded_at: string;
+}
+
 export interface ChildTask {
   id: string;
   child_id: string;

--- a/supabase/migrations/20250615120000_add_missions_badges.sql
+++ b/supabase/migrations/20250615120000_add_missions_badges.sql
@@ -1,0 +1,105 @@
+/*
+  # Ajout des missions et des badges
+
+  Cette migration crée les tables necessaires pour suivre des missions ludiques
+  et attribuer des badges aux enfants.
+
+  Nouvelles tables
+    - missions
+    - mission_steps
+    - child_missions
+    - badges
+    - child_badges
+*/
+
+-- Table missions
+CREATE TABLE IF NOT EXISTS missions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE NOT NULL,
+  title text NOT NULL,
+  description text,
+  category text DEFAULT 'divers',
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE missions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Parents manage their missions"
+  ON missions FOR ALL
+  TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Table mission_steps
+CREATE TABLE IF NOT EXISTS mission_steps (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  mission_id uuid REFERENCES missions(id) ON DELETE CASCADE NOT NULL,
+  label text NOT NULL,
+  step_order integer DEFAULT 0,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE mission_steps ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Parents manage their mission steps"
+  ON mission_steps FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM missions WHERE id = mission_id AND user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM missions WHERE id = mission_id AND user_id = auth.uid()));
+
+-- Table child_missions
+CREATE TABLE IF NOT EXISTS child_missions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  child_id uuid REFERENCES children(id) ON DELETE CASCADE NOT NULL,
+  mission_id uuid REFERENCES missions(id) ON DELETE CASCADE NOT NULL,
+  current_step integer DEFAULT 0,
+  is_completed boolean DEFAULT false,
+  validated boolean DEFAULT false,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE child_missions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Parents manage child missions"
+  ON child_missions FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM children WHERE id = child_id AND user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM children WHERE id = child_id AND user_id = auth.uid()));
+
+-- Table badges
+CREATE TABLE IF NOT EXISTS badges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  title text NOT NULL,
+  description text,
+  icon_url text,
+  created_at timestamptz DEFAULT now()
+);
+
+ALTER TABLE badges ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read badges"
+  ON badges FOR SELECT
+  USING (true);
+
+CREATE POLICY "Parents manage badges"
+  ON badges FOR INSERT, UPDATE, DELETE
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+-- Table child_badges
+CREATE TABLE IF NOT EXISTS child_badges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  child_id uuid REFERENCES children(id) ON DELETE CASCADE NOT NULL,
+  badge_id uuid REFERENCES badges(id) ON DELETE CASCADE NOT NULL,
+  awarded_at timestamptz DEFAULT now(),
+  UNIQUE(child_id, badge_id)
+);
+
+ALTER TABLE child_badges ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Parents manage child badges"
+  ON child_badges FOR ALL
+  TO authenticated
+  USING (EXISTS (SELECT 1 FROM children WHERE id = child_id AND user_id = auth.uid()))
+  WITH CHECK (EXISTS (SELECT 1 FROM children WHERE id = child_id AND user_id = auth.uid()));


### PR DESCRIPTION
## Summary
- support missions and badges
- create migration for missions and badges tables
- add mission management interface for parents
- show badge gallery on child dashboard
- document new tables and migration

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684ea3f33958832689948b349e1bda1a