### PR TITLE
Fix wrapping for child dashboard nav

### DIFF
--- a/src/pages/child-dashboard.tsx
+++ b/src/pages/child-dashboard.tsx
@@ -1858,7 +1858,7 @@ export default function ChildDashboard() {
       {/* Indicateurs flottants fixes en bas */}
       <div className="fixed bottom-0 left-0 right-0 z-40 bg-white/90 backdrop-blur-sm border-t border-purple-200 shadow-lg">
         <div className="container mx-auto px-4 py-3">
-          <div className="flex items-center justify-center gap-4">
+          <div className="flex flex-wrap items-center justify-center gap-3 sm:gap-4">
             {/* Missions non complétées */}
             <div className="relative group">
               <div 


### PR DESCRIPTION
## Summary
- ensure bottom nav icons can wrap on small screens

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6853aed054888326b3e35841361f220f