### PR TITLE
Use env var for OpenWeather API key

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,10 @@ Une application moderne et interactive pour aider les parents à gérer les tâc
    VITE_SUPABASE_URL=your_supabase_url
    VITE_SUPABASE_ANON_KEY=your_supabase_anon_key
    VITE_GEMINI_API_KEY=your_google_generative_ai_key
+   VITE_OPENWEATHER_KEY=your_openweather_key
    ```
    La clé `VITE_GEMINI_API_KEY` est utilisée pour contacter l'API Google Gemini afin de générer automatiquement des suggestions de tâches, règles ou récompenses et pour l'analyse IA du tableau de bord enfant.
+   La clé `VITE_OPENWEATHER_KEY` permet de récupérer les données météo depuis OpenWeatherMap.
 
 4. Exécuter les migrations Supabase :
    - `create_initial_schema.sql`

--- a/src/components/WeatherWidget.tsx
+++ b/src/components/WeatherWidget.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { toast } from '@/hooks/use-toast';
 
 interface WeatherData {
   name: string;
@@ -22,19 +23,30 @@ interface WeatherWidgetProps {
   mode?: 'full';
 }
 
-const API_KEY = '942c1a83a2948447b2ba4e057708b506';
 
 export default function WeatherWidget({ city = 'Paris', mode }: WeatherWidgetProps) {
   const [weather, setWeather] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const apiKey = import.meta.env.VITE_OPENWEATHER_KEY;
 
   useEffect(() => {
     setLoading(true);
     setError(null);
+    if (!apiKey) {
+      toast({
+        title: 'Erreur',
+        description: 'Clé API OpenWeather manquante',
+        variant: 'destructive',
+      });
+      setError('Clé API OpenWeather manquante');
+      setLoading(false);
+      return;
+    }
+
     if (mode === 'full') {
       fetch(
-        `https://api.openweathermap.org/data/2.5/forecast?q=${encodeURIComponent(city)}&appid=${API_KEY}&units=metric&lang=fr`
+        `https://api.openweathermap.org/data/2.5/forecast?q=${encodeURIComponent(city)}&appid=${apiKey}&units=metric&lang=fr`
       )
         .then((res) => {
           if (!res.ok) throw new Error('Erreur lors de la récupération de la météo');
@@ -50,7 +62,7 @@ export default function WeatherWidget({ city = 'Paris', mode }: WeatherWidgetPro
         });
     } else {
       fetch(
-        `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${API_KEY}&units=metric&lang=fr`
+        `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}&units=metric&lang=fr`
       )
         .then((res) => {
           if (!res.ok) throw new Error('Erreur lors de la récupération de la météo');

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -76,8 +76,11 @@ export function formatNumber(num: number): string {
 
 // Fonction utilitaire pour obtenir la météo actuelle d'une ville (OpenWeatherMap)
 export async function getWeather(city: string = 'Paris') {
-  const API_KEY = '942c1a83a2948447b2ba4e057708b506';
-  const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${API_KEY}&units=metric&lang=fr`;
+  const apiKey = import.meta.env.VITE_OPENWEATHER_KEY;
+  if (!apiKey) {
+    throw new Error('Missing VITE_OPENWEATHER_KEY');
+  }
+  const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&appid=${apiKey}&units=metric&lang=fr`;
   const res = await fetch(url);
   if (!res.ok) throw new Error('Erreur lors de la récupération de la météo');
   const data = await res.json();

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_SUPABASE_URL?: string;
+  readonly VITE_SUPABASE_ANON_KEY?: string;
+  readonly VITE_GEMINI_API_KEY?: string;
+  readonly VITE_OPENWEATHER_KEY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react()],
+  envPrefix: 'VITE_',
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- load OpenWeatherMap API key from `import.meta.env`
- surface error toast when key is missing
- expose `VITE_OPENWEATHER_KEY` in `vite.config.ts`
- type the new variable in `vite-env.d.ts`
- document the new env var in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to environment limits)*

------
https://chatgpt.com/codex/tasks/task_e_6853aed212c883268a0e4958973389fd